### PR TITLE
Prevents shadowing a variable in another scope block

### DIFF
--- a/gcm.go
+++ b/gcm.go
@@ -410,7 +410,7 @@ func sendHttp(apiKey string, m HttpMessage, c httpClient, b backoffProvider) (*H
 	copy(localTo, targets)
 	resultsState := &multicastResultsState{}
 	for b.sendAnother() {
-		gcmResp, err := c.send(apiKey, m)
+		gcmResp, err = c.send(apiKey, m)
 		if err != nil {
 			return gcmResp, fmt.Errorf("error sending request to GCM HTTP server: %v", err)
 		}


### PR DESCRIPTION
Previous code has shadowed a variable in another scope, therefore it never returned a real HttpResponse body after a break loop statement. After this minor fix, I was able to receive working `&HttpResponse` on a `gcm.SendHttp()` callback.