### PR TITLE
Fix #31 change end point to new FCM.

### DIFF
--- a/gcm.go
+++ b/gcm.go
@@ -36,8 +36,8 @@ const (
 	CCSNack     = "nack"
 	CCSControl  = "control"
 	CCSReceipt  = "receipt"
-	httpAddress = "https://gcm-http.googleapis.com/gcm/send"
-	xmppHost    = "gcm-xmpp.googleapis.com"
+	httpAddress = "https://fcm.googleapis.com/fcm/send"
+	xmppHost    = "fcm-xmpp.googleapis.com"
 	xmppPort    = "5235"
 	xmppAddress = xmppHost + ":" + xmppPort
 	// For ccs the min for exponential backoff has to be 1 sec


### PR DESCRIPTION
[Firebase Cloud Messaging (FCM)](https://firebase.google.com/docs/cloud-messaging/) is the new version of GCM. It inherits the reliable and scalable GCM infrastructure, plus new features! See the FAQ to learn more. If you are integrating messaging in a new app, start with FCM. GCM users are strongly recommended to upgrade to FCM, in order to benefit from new FCM features today and in the future.