### PR TITLE
Expose the status of requests

### DIFF
--- a/gcm.go
+++ b/gcm.go
@@ -107,12 +107,13 @@ type XmppMessage struct {
 
 // HttpResponse is the GCM connection server response to an HTTP downstream message request.
 type HttpResponse struct {
+	Status       int      `json:"-"`
 	MulticastId  int      `json:"multicast_id,omitempty"`
 	Success      uint     `json:"success,omitempty"`
 	Failure      uint     `json:"failure,omitempty"`
 	CanonicalIds uint     `json:"canonical_ids,omitempty"`
 	Results      []Result `json:"results,omitempty"`
-	MessageId    int     `json:"message_id,omitempty"`
+	MessageId    int      `json:"message_id,omitempty"`
 	Error        string   `json:"error,omitempty"`
 }
 
@@ -194,6 +195,12 @@ func (c *httpGcmClient) send(apiKey string, m HttpMessage) (*HttpResponse, error
 		return nil, fmt.Errorf("error sending request to HTTP connection server>%v", err)
 	}
 	gcmResp := &HttpResponse{}
+	gcmResp.Status = httpResp.StatusCode
+
+	if gcmResp.Status != http.StatusOK {
+		return gcmResp, fmt.Errorf("Encountered HTTP status code %d", gcmResp.Status)
+	}
+
 	body, err := ioutil.ReadAll(httpResp.Body)
 	defer httpResp.Body.Close()
 	if err != nil {

--- a/gcm_test.go
+++ b/gcm_test.go
@@ -129,6 +129,7 @@ func TestHttpClientSend(t *testing.T) {
 	expectedAuthHeader := "key=apiKey"
 	expResp := &HttpResponse{}
 	err := json.Unmarshal([]byte(expectedResp), &expResp)
+	expResp.Status = http.StatusOK
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}


### PR DESCRIPTION
Hi there,

Whenever I got 401 errors, the library would panic. The GCM response for 401s are in HTML, whereas the library was trying to parse the body from JSON regardless of the status.

This PR adds a `Status` field to the `HttpResponse` struct, and also returns an error upon a non-200 response.

Let me know what you think
