### PR TITLE
accept appengine users

### DIFF
--- a/gcm.go
+++ b/gcm.go
@@ -65,6 +65,7 @@ var (
 	}{
 		m: make(map[string]*xmppGcmClient),
 	}
+	Client *http.Client
 )
 
 // Prints debug info if DebugMode is set.
@@ -463,7 +464,10 @@ func (eb exponentialBackoff) wait() {
 
 // Send a message using the HTTP GCM connection server.
 func SendHttp(apiKey string, m HttpMessage) (*HttpResponse, error) {
-	c := &httpGcmClient{httpAddress, &http.Client{}, "0"}
+	if Client == nil {
+		Client = &http.Client{}
+	}
+	c := &httpGcmClient{httpAddress, Client, "0"}
 	b := newExponentialBackoff()
 	return sendHttp(apiKey, m, c, b)
 }


### PR DESCRIPTION
usage:

import (
"github.com/google/go-gcm"
"net/http"
"appengine"
"appengine/urlfetch"
)

var key = "your api key"

c := appengine.NewContext(r)
client := urlfetch.Client(c)
gcm.Client = client
m := gcm.HttpMessage{RegistrationIds: regIDs, Data: data}
_, err := gcm.SendHttp(key, m)
